### PR TITLE
Implement getUserCount API

### DIFF
--- a/api-signaling/src/main/kotlin/org/example/api_signaling/controller/SignalingController.kt
+++ b/api-signaling/src/main/kotlin/org/example/api_signaling/controller/SignalingController.kt
@@ -1,17 +1,57 @@
 package org.example.api_signaling.controller
 
 import lombok.extern.slf4j.Slf4j
+import org.springframework.context.event.EventListener
+import org.springframework.messaging.handler.annotation.DestinationVariable
+import org.springframework.messaging.handler.annotation.Header
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.SendTo
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.socket.messaging.SessionDisconnectEvent
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.jvm.internal.impl.load.kotlin.JvmType
 
 @Slf4j
 @Controller
 class SignalingController {
+    val sessionIdToRoomId = ConcurrentHashMap<String, String>()
+    val roomIdToUserSet = ConcurrentHashMap<String, Set<String>>()
+
+    @ResponseBody
+    @GetMapping("/room/{roomId}/count")
+    fun getUserCount(@PathVariable roomId: String): Map<String, Any?> {
+        val userCount = roomIdToUserSet[roomId]?.size
+
+        val resBody = mutableMapOf<String, Any?>()
+        resBody["userCount"] = userCount
+        return resBody
+    }
+
+    @EventListener
+    fun handleDisconnectEvent(event: SessionDisconnectEvent) {
+        val roomId = sessionIdToRoomId[event.sessionId] ?: return
+        roomIdToUserSet.compute(roomId) { _, userSet ->
+            val updatedSet = userSet?.toMutableSet() ?: mutableSetOf()
+            updatedSet.remove(event.sessionId)
+            sessionIdToRoomId.remove(event.sessionId)
+            updatedSet
+        }
+    }
+
     @MessageMapping("/{roomId}")
     @SendTo("/topic/{roomId}")
     @Throws(Exception::class)
-    fun joinRoom(key: String): String {
+    fun joinRoom(key: String, @DestinationVariable roomId: String, @Header simpSessionId: String, session: SimpMessageHeaderAccessor): String {
+        sessionIdToRoomId[simpSessionId] = roomId
+        roomIdToUserSet.compute(roomId) { _, userSet ->
+            val updatedSet = userSet?.toMutableSet() ?: mutableSetOf()
+            updatedSet.add(simpSessionId)
+            updatedSet
+        }
         return key
     }
 


### PR DESCRIPTION
- GetUserCount API 구현
  - Path : `room/{roomId}/count`
  - response body
    ```json
    {
        "userCount" : <number>
    }
    ```

- 상세 구현 내역
  - room 마다 참여하고 있는 user set을 관리하여 userCount 를 알 수 있도록 합니다.
  - user 입장 시 동작
    - user 는 입장시 `/topic/{roomId}` 로 message 를 보냅니다.
    - 이 때, userSet 에 해당 user의 sessionId 를 추가합니다.
  - user 퇴장 시 동작
    - Websocket session 이 close 될 때, [SessionDisconnectEvent](https://docs.spring.io/spring-framework/docs/4.3.x/spring-framework-reference/html/websocket.html#websocket-stomp-appplication-context-events) 가 발생합니다.
    - SessionDisconnectEvent 가 발생하면, 해당 room의 userSet 에서 해당 user의 sessionId 를 제거합니다.